### PR TITLE
Feature/refactor makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXX_FLAGS=-std=c++20 -I./include -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -Wundef -Werror -Wno-unused
+override CXX_FLAGS+=-std=c++20 -I./include -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -Wundef -Werror -Wno-unused
 DEBUG_CXX_FLAGS=-g -Weffc++
 RELEASE_CXX_FLAGS=-O1 -flto=auto -march=native -DNDEBUG
 
@@ -27,69 +27,16 @@ debug_birb_db: debug_birb
 optimized: optimized_dep_solver optimized_pkg_search optimized_birb_db
 
 optimized_birb: build_dir
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -g -c ${SRC_DIR}/birb.cpp -o ${BUILD_DIR}/birb.o
+	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -c ${SRC_DIR}/birb.cpp -o ${BUILD_DIR}/birb.o
 
 optimized_dep_solver: optimized_birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -g ${SRC_DIR}/dep_solver.cpp -o ${BUILD_DIR}/birb_dep_solver ${BUILD_DIR}/birb.o
+	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} ${SRC_DIR}/dep_solver.cpp -o ${BUILD_DIR}/birb_dep_solver ${BUILD_DIR}/birb.o
 
 optimized_pkg_search: optimized_birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -g ${SRC_DIR}/pkg_search.cpp -o ${BUILD_DIR}/birb_pkg_search ${BUILD_DIR}/birb.o
+	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} ${SRC_DIR}/pkg_search.cpp -o ${BUILD_DIR}/birb_pkg_search ${BUILD_DIR}/birb.o
 
 optimized_birb_db: optimized_birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -g ${SRC_DIR}/birb_db.cpp -o ${BUILD_DIR}/birb_db ${BUILD_DIR}/birb.o
-
-
-
-release: birb_dep_solver birb_pkg_search birb_db
-
-
-# birb.o library
-birb: birb_profile_run birb_dep_solver_profile_run birb_pkg_search_profile_run birb_db_profile_run
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -fprofile-use -c ${SRC_DIR}/birb.cpp -o ${BUILD_DIR}/birb.o
-
-birb_profile_run: birb_profile_gen
-
-birb_profile_gen: build_dir
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -fprofile-generate -c ${SRC_DIR}/birb.cpp -o ${BUILD_DIR}/birb.o
-
-
-# birb_dep_solver
-birb_dep_solver: birb_dep_solver_profile_run birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -fprofile-use ${SRC_DIR}/dep_solver.cpp -o ${BUILD_DIR}/birb_dep_solver ${BUILD_DIR}/birb.o
-
-birb_dep_solver_profile_run: birb_dep_solver_profile_gen
-	${BUILD_DIR}/birb_dep_solver dde &>/dev/null
-	${BUILD_DIR}/birb_dep_solver firefox &>/dev/null
-	${BUILD_DIR}/birb_dep_solver -r ncurses &>/dev/null
-
-birb_dep_solver_profile_gen: build_dir birb_profile_gen
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -fprofile-generate ${SRC_DIR}/dep_solver.cpp -o ${BUILD_DIR}/birb_dep_solver ${BUILD_DIR}/birb.o
-
-
-# birb_pkg_search
-birb_pkg_search: birb_pkg_search_profile_run birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -fprofile-use ${SRC_DIR}/pkg_search.cpp -o ${BUILD_DIR}/birb_pkg_search ${BUILD_DIR}/birb.o
-
-birb_pkg_search_profile_run: birb_pkg_search_profile_gen
-	${BUILD_DIR}/birb_pkg_search iceauth luit mkfontscale sessreg setxkbmap smproxy x11perf xauth xbacklight xcmsdb xcursorgen xdpyinfo xdriinfo xev xgamma xhost xinput xkbcomp xkbevd xkbutils xkill xlsatoms xlsclients xmessage xmodmap xpr xprop xrandr xrdb xrefresh xset xsetroot xvinfo xwd xwininfo xwud &>/dev/null
-
-birb_pkg_search_profile_gen: build_dir birb_profile_gen
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -fprofile-generate ${SRC_DIR}/pkg_search.cpp -o ${BUILD_DIR}/birb_pkg_search ${BUILD_DIR}/birb.o
-
-
-# birb_db
-birb_db: birb_db_profile_run birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -fprofile-use ${SRC_DIR}/birb_db.cpp -o ${BUILD_DIR}/birb_db ${BUILD_DIR}/birb.o
-
-birb_db_profile_run: birb_db_profile_gen
-	${BUILD_DIR}/birb_db --update this_package_will_not_exist 1.2.3
-	${BUILD_DIR}/birb_db --list &>/dev/null
-	${BUILD_DIR}/birb_db --remove this_package_will_not_exist
-	${BUILD_DIR}/birb_db --is-installed ncurses &>/dev/null
-	${BUILD_DIR}/birb_db --is-installed alweiuhlawiuefhu &>/dev/null
-
-birb_db_profile_gen: build_dir birb_profile_gen
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -fprofile-generate ${SRC_DIR}/birb_db.cpp -o ${BUILD_DIR}/birb_db ${BUILD_DIR}/birb.o
+	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} ${SRC_DIR}/birb_db.cpp -o ${BUILD_DIR}/birb_db ${BUILD_DIR}/birb.o
 
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,27 @@
 CXX=g++
+
 override CXX_FLAGS+=-std=c++20 -I./include -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -Wundef -Werror -Wno-unused
-DEBUG_CXX_FLAGS=-g -Weffc++
-RELEASE_CXX_FLAGS=-O1 -flto=auto -march=native -DNDEBUG
 
 SRC_DIR=./src
 BUILD_DIR=./build
 
-all: debug_dep_solver debug_pkg_search debug_birb_db
+all: dep_solver pkg_search birb_db
 
 build_dir:
 	mkdir -p ${BUILD_DIR}
 
-debug_birb: build_dir
-	${CXX} ${CXX_FLAGS} ${DEBUG_CXX_FLAGS} -c ${SRC_DIR}/birb.cpp -o ${BUILD_DIR}/birb.o
+birb: build_dir
+	${CXX} ${CXX_FLAGS} -c ${SRC_DIR}/birb.cpp -o ${BUILD_DIR}/birb.o
 
-debug_dep_solver: debug_birb
-	${CXX} ${CXX_FLAGS} ${DEBUG_CXX_FLAGS} ${SRC_DIR}/dep_solver.cpp -o ${BUILD_DIR}/birb_dep_solver ${BUILD_DIR}/birb.o
+dep_solver: birb
+	${CXX} ${CXX_FLAGS} ${SRC_DIR}/dep_solver.cpp -o ${BUILD_DIR}/birb_dep_solver ${BUILD_DIR}/birb.o
 
-debug_pkg_search: debug_birb
-	${CXX} ${CXX_FLAGS} ${DEBUG_CXX_FLAGS} ${SRC_DIR}/pkg_search.cpp -o ${BUILD_DIR}/birb_pkg_search ${BUILD_DIR}/birb.o
+pkg_search: birb
+	${CXX} ${CXX_FLAGS} ${SRC_DIR}/pkg_search.cpp -o ${BUILD_DIR}/birb_pkg_search ${BUILD_DIR}/birb.o
 
-debug_birb_db: debug_birb
-	${CXX} ${CXX_FLAGS} ${DEBUG_CXX_FLAGS} ${SRC_DIR}/birb_db.cpp -o ${BUILD_DIR}/birb_db ${BUILD_DIR}/birb.o
+birb_db: birb
+	${CXX} ${CXX_FLAGS} ${SRC_DIR}/birb_db.cpp -o ${BUILD_DIR}/birb_db ${BUILD_DIR}/birb.o
 
-
-optimized: optimized_dep_solver optimized_pkg_search optimized_birb_db
-
-optimized_birb: build_dir
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} -c ${SRC_DIR}/birb.cpp -o ${BUILD_DIR}/birb.o
-
-optimized_dep_solver: optimized_birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} ${SRC_DIR}/dep_solver.cpp -o ${BUILD_DIR}/birb_dep_solver ${BUILD_DIR}/birb.o
-
-optimized_pkg_search: optimized_birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} ${SRC_DIR}/pkg_search.cpp -o ${BUILD_DIR}/birb_pkg_search ${BUILD_DIR}/birb.o
-
-optimized_birb_db: optimized_birb
-	${CXX} ${CXX_FLAGS} ${RELEASE_CXX_FLAGS} ${SRC_DIR}/birb_db.cpp -o ${BUILD_DIR}/birb_db ${BUILD_DIR}/birb.o
 
 
 install:

--- a/birb
+++ b/birb
@@ -1141,13 +1141,16 @@ birb_upgrade()
 
 	make clean
 
+	DEBUG_CXX_FLAGS="-g -Weffc++"
+	RELEASE_CXX_FLAGS="-O1 -flto=auto -march=native -DNDEBUG"
+
 	if [ "$1" == "debug" ]
 	then
-		make
+		make CXX_FLAGS="$DEBUG_CXX_FLAGS"
 	else
-		make CXX_FLAGS="-fprofile-generate" optimized -j$(nproc)
+		make CXX_FLAGS="-fprofile-generate $RELEASE_CXX_FLAGS" optimized -j$(nproc)
 		./pgo_run.sh
-		make CXX_FLAGS="-fprofile-use" optimized -j$(nproc)
+		make CXX_FLAGS="-fprofile-use $RELEASE_CXX_FLAGS" optimized -j$(nproc)
 	fi
 
 	make install

--- a/birb
+++ b/birb
@@ -1140,7 +1140,16 @@ birb_upgrade()
 	git pull
 
 	make clean
-	[ "$1" == "debug" ] && make || make release -j$(nproc)
+
+	if [ "$1" == "debug" ]
+	then
+		make
+	else
+		make CXX_FLAGS="-fprofile-generate" optimized -j$(nproc)
+		./pgo_run.sh
+		make CXX_FLAGS="-fprofile-use" optimized -j$(nproc)
+	fi
+
 	make install
 
 	println "Upgrade finished successfully"

--- a/pgo_run.sh
+++ b/pgo_run.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+BUILD_DIR="$(dirname $0)/build"
+BINARIES_TO_RUN="birb_db birb_dep_solver birb_pkg_search"
+
+# Make sure that the build directory exists
+if [ ! -d "$BUILD_DIR" ]
+then
+	echo "Build directory doesn't exist!"
+	exit 1
+fi
+
+# Make sure that all binaries were built
+for i in $BINARIES_TO_RUN
+do
+	if [ ! -f "$BUILD_DIR/$i" ]
+	then
+		echo "Missing binary: $i"
+		echo "Did you build everything?"
+		exit 1
+	fi
+done
+
+# PGO test run functions
+_birb_db()
+{
+	echo "Running: birb_db"
+	${BUILD_DIR}/birb_db --update this_package_will_not_exist 1.2.3
+	${BUILD_DIR}/birb_db --list &>/dev/null
+	${BUILD_DIR}/birb_db --remove this_package_will_not_exist
+	${BUILD_DIR}/birb_db --is-installed ncurses &>/dev/null
+	${BUILD_DIR}/birb_db --is-installed alweiuhlawiuefhu &>/dev/null
+}
+
+_birb_dep_solver()
+{
+	echo "Running: birb_dep_solver"
+	${BUILD_DIR}/birb_dep_solver dde &>/dev/null
+	${BUILD_DIR}/birb_dep_solver firefox &>/dev/null
+	${BUILD_DIR}/birb_dep_solver -r ncurses &>/dev/null
+}
+
+_birb_pkg_search()
+{
+	echo "Running: birb_pkg_search"
+	${BUILD_DIR}/birb_pkg_search iceauth luit mkfontscale sessreg setxkbmap smproxy x11perf xauth xbacklight xcmsdb xcursorgen xdpyinfo xdriinfo xev xgamma xhost xinput xkbcomp xkbevd xkbutils xkill xlsatoms xlsclients xmessage xmodmap xpr xprop xrandr xrdb xrefresh xset xsetroot xvinfo xwd xwininfo xwud &>/dev/null
+}
+
+# Run the functions
+_birb_db
+_birb_dep_solver
+_birb_pkg_search


### PR DESCRIPTION
Simplify the Makefile in the following ways:
- Move the PGO run commands into a separate script file
- Let birb decide the optimization build flags during upgrade
- Merge debug and optimization build targets into one general target