### PR TITLE
Implement developer mode

### DIFF
--- a/birb
+++ b/birb
@@ -1116,6 +1116,7 @@ birb_upgrade()
 	root_check
 	println "Upgrading birb ^-^"
 	[ "$1" == "debug" ] && echo " --- Debug mode enabled ＿φ(°-°=) ---"
+	[ "$BIRB_DEV_MODE" == "true" ] && echo " ----- Development mode enabled (O_O;) -----"
 
 	# Check if birb is in the distfile cache
 	# If it doesn't, clone it with git
@@ -1136,6 +1137,40 @@ birb_upgrade()
 	set -e
 
 	cd $BIRB_DIST
+
+	# Check if we are in the correct branch
+	CURRENT_BIRB_BRANCH="$(git status | head -n1 | cut -d' ' -f3)"
+	case $CURRENT_BIRB_BRANCH in
+		# We are in a stable branch
+		main)
+			case $BIRB_DEV_MODE in
+				true)
+					# Make sure that a development branch exists at the moment
+					# If so, switch to it
+					if [ -n "$(git branch | awk '/^[[:space:]]*dev$/')" ]
+					then
+						git switch dev
+					else
+						println WARNING "The development branch doesn't seem to exist at the moment. Staying in main..."
+					fi
+					;;
+
+				*) ;;
+			esac
+			;;
+
+		# We are in a development branch
+		dev)
+			case $BIRB_DEV_MODE in
+				true) ;;
+				*) git switch main ;;
+			esac
+			;;
+
+		# We are in some other branch, switch back to main
+		*) git switch main ;;
+	esac
+
 	git fetch
 	git pull
 

--- a/birb.conf
+++ b/birb.conf
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Developer mode
+# 	If this variable is set to true, birb will use the dev branch
+# 	instead of the more stable main branch when fetching updates
+export BIRB_DEV_MODE=false
+
+
 # NOTE: These custom compiler flags only apply to the 64bit libraries
 
 # Custom CFLAGS to use in addition to package specific CFLAGS


### PR DESCRIPTION
The developer mode will make switching between a main and development branch easier. Moving development away from main should increase stability and make life easier for those who aren't involved with the development.