### PR TITLE
Use git checkout when switching to dev branch

### DIFF
--- a/birb
+++ b/birb
@@ -1144,17 +1144,7 @@ birb_upgrade()
 		# We are in a stable branch
 		main)
 			case $BIRB_DEV_MODE in
-				true)
-					# Make sure that a development branch exists at the moment
-					# If so, switch to it
-					if [ -n "$(git branch | awk '/^[[:space:]]*dev$/')" ]
-					then
-						git switch dev
-					else
-						println WARNING "The development branch doesn't seem to exist at the moment. Staying in main..."
-					fi
-					;;
-
+				true) git checkout dev ;;
 				*) ;;
 			esac
 			;;


### PR DESCRIPTION
This fixes cases where the development branch might not exist at the moment