### PR TITLE
Unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CXX=g++
 
 override CXXFLAGS+=-std=c++20 -static -I./include -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2 -Winit-self -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wnoexcept -Woverloaded-virtual -Wsign-promo -Wstrict-null-sentinel -Wundef -Werror -Wno-unused
+FRONTEND_CXXFLAGS=-flto=auto -DDOCTEST_CONFIG_DISABLE
 
 SRC_DIR=./src
 BUILD_DIR=./build
@@ -13,28 +14,31 @@ build_dir:
 
 #### Backend ####
 database: build_dir
-	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/backend/$@.cpp -o $(BUILD_DIR)/$@.o
+	$(CXX) $(CXXFLAGS) -DDOCTEST_CONFIG_IMPLEMENT -c $(SRC_DIR)/backend/$@.cpp -o $(BUILD_DIR)/$@.o
 
 dependencies: build_dir
-	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/backend/$@.cpp -o $(BUILD_DIR)/$@.o
+	$(CXX) $(CXXFLAGS) -DDOCTEST_CONFIG_IMPLEMENT -c $(SRC_DIR)/backend/$@.cpp -o $(BUILD_DIR)/$@.o
 
 utils: build_dir
-	$(CXX) $(CXXFLAGS) -c $(SRC_DIR)/backend/$@.cpp -o $(BUILD_DIR)/$@.o
+	$(CXX) $(CXXFLAGS) -DDOCTEST_CONFIG_IMPLEMENT -c $(SRC_DIR)/backend/$@.cpp -o $(BUILD_DIR)/$@.o
 
 
 birb_lib: database dependencies utils
 	ar -rcs $(BUILD_DIR)/libbirb.a $(BUILD_DIR)/{database,dependencies,utils}.o
 
+#### Testing ####
+test: birb_lib
+	$(CXX) $(CXXFLAGS) $(SRC_DIR)/birb_test.cpp -o $(BUILD_DIR)/birb_test $(BUILD_DIR)/utils.o
 
 #### Frontend ####
 dep_solver: birb_lib
-	$(CXX) $(CXXFLAGS) -flto=auto $(SRC_DIR)/frontend/dep_solver.cpp -o $(BUILD_DIR)/birb_dep_solver $(BUILD_DIR)/libbirb.a
+	$(CXX) $(CXXFLAGS) $(FRONTEND_CXXFLAGS) $(SRC_DIR)/frontend/dep_solver.cpp -o $(BUILD_DIR)/birb_dep_solver $(BUILD_DIR)/libbirb.a
 
 pkg_search: birb_lib
-	$(CXX) $(CXXFLAGS) -flto=auto $(SRC_DIR)/frontend/pkg_search.cpp -o $(BUILD_DIR)/birb_pkg_search $(BUILD_DIR)/libbirb.a
+	$(CXX) $(CXXFLAGS) $(FRONTEND_CXXFLAGS) $(SRC_DIR)/frontend/pkg_search.cpp -o $(BUILD_DIR)/birb_pkg_search $(BUILD_DIR)/libbirb.a
 
 birb_db: birb_lib
-	$(CXX) $(CXXFLAGS) -flto=auto $(SRC_DIR)/frontend/birb_db.cpp -o $(BUILD_DIR)/birb_db $(BUILD_DIR)/libbirb.a
+	$(CXX) $(CXXFLAGS) $(FRONTEND_CXXFLAGS) $(SRC_DIR)/frontend/birb_db.cpp -o $(BUILD_DIR)/birb_db $(BUILD_DIR)/libbirb.a
 
 
 

--- a/birb
+++ b/birb
@@ -80,7 +80,7 @@ print_help()
 	echo "      --sync [--force]               sync package repositories"
 	echo "      --list-installed               list all currently installed packages"
 	echo "      --update                       update out-of-date packages"
-	echo "      --upgrade [--debug]            update the birb package manager"
+	echo "      --upgrade [--debug|--test]     update the birb package manager"
 	echo ""
 	echo "If a valid package names are given as the only arguments, birb will attempt"
 	echo "downloading and installing them"
@@ -1182,6 +1182,14 @@ birb_upgrade()
 		make CXXFLAGS="-fprofile-use $RELEASE_CXXFLAGS" -j$(nproc)
 	fi
 
+	if [ "$1" == "test" ]
+	then
+		make CXXFLAGS="$RELEASE_CXXFLAGS" -j$(nproc) test
+
+		# Run the tests and cancel the upgrade if they fail
+		./build/birb_test || { println ERROR "Tests failed! Cancelling the upgrade..."; exit 1; }
+	fi
+
 	make install
 
 	println "Upgrade finished successfully"
@@ -1421,6 +1429,10 @@ while test $# -gt 0; do
 			case $1 in
 				--debug)
 					birb_upgrade debug
+					;;
+
+				--test)
+					birb_upgrade test
 					;;
 
 				*)

--- a/birb.1
+++ b/birb.1
@@ -53,8 +53,12 @@ List all currently installed packages
 \fB--update\fP
 Find all packages that are out-of-date and attempt to update them. In most cases you should be able to cancel the update after you have already started it and \fBbirb\fP should be able to restore things back, but if anything goes wrong, you can find (usually) a backup of the package fakeroot from /var/backup/birb/fakeroot_backups.
 .TP
-\fB--upgrade [--debug]\fP
-Update the birb package manager. If --debug is set, build the C++ parts of birb with debug flags enabled and skip PGO and LTO.
+\fB--upgrade [--debug|--test]\fP
+Update the birb package manager.
+
+If --debug is set, build the C++ parts of birb with debug flags enabled and skip PGO and LTO.
+
+If --test is set, compile \fBbirb\fP like normal with all optimizations enabled, but on top of that compile tests and run them. If the tests fail, cancel the upgrade.
 .TP
 \fB--repair\fP
 Attempt to recover a broken system (due to missing packages) by using the package database as a ground truth for what should be installed on the system. This way we can reinstall packages that have their files missing, but the system still thinks that the package is already installed.

--- a/src/backend/utils.cpp
+++ b/src/backend/utils.cpp
@@ -1,9 +1,11 @@
+#include <doctest/doctest.h>
 #include "Utils.hpp"
 #include <cassert>
 #include <fstream>
 #include <iostream>
 #include <string.h>
 #include <unistd.h>
+#include <vector>
 
 namespace birb
 {
@@ -46,6 +48,39 @@ namespace birb
 			result.push_back(text);
 
 		return result;
+	}
+
+	TEST_CASE("split_string()")
+	{
+		SUBCASE("One char delimiter")
+		{
+			std::vector<std::string> A = split_string("The quick brown fox jumps over the lazy dog", " ");
+			CHECK(A.size() == 9);
+			CHECK(A[0] == "The");
+			CHECK(A[1] == "quick");
+			CHECK(A[2] == "brown");
+			CHECK(A[3] == "fox");
+			CHECK(A[4] == "jumps");
+			CHECK(A[5] == "over");
+			CHECK(A[6] == "the");
+			CHECK(A[7] == "lazy");
+			CHECK(A[8] == "dog");
+		}
+
+		SUBCASE("One char delimiter with no splits")
+		{
+			std::vector<std::string> A = split_string("Hello_world!", " ");
+			CHECK(A.size() == 1);
+			CHECK(A[0] == "Hello_world!");
+		}
+
+		SUBCASE("Multichar delimiter")
+		{
+			std::vector<std::string> A = split_string("HelloASDworld!", "ASD");
+			CHECK(A.size() == 2);
+			CHECK(A[0] == "Hello");
+			CHECK(A[1] == "world!");
+		}
 	}
 
 	std::vector<std::string> read_file(const std::string& file_path)

--- a/src/birb_test.cpp
+++ b/src/birb_test.cpp
@@ -1,0 +1,19 @@
+#define DDOCTEST_CONFIG_IMPLEMENT
+#include <doctest/doctest.h>
+
+/* This file is empty on puporse
+ *
+ * It is simply an entry for doctest to implement its
+ * main() function. The tests will be implemented below
+ * the functions that they are testing
+ *
+ * The test code will be removed from the final binaries during linking */
+
+int main(int argc, char** argv)
+{
+	doctest::Context context;
+	context.applyCommandLine(argc, argv);
+
+	int res = context.run();
+	return res;
+}


### PR DESCRIPTION
Create a base for unit testing

The unit tests can be added right below the code that is being tested. The tests will be built into the birb_test binary that won't be installed to the system, but can optionally be run during upgrades to see if things work as intended